### PR TITLE
Adding unparallelize option to roaster

### DIFF
--- a/jiffy/roaster_inspector.py
+++ b/jiffy/roaster_inspector.py
@@ -71,11 +71,6 @@ class RoasterInspector(object):
         self._load_roaster_file(args)
         self._load_roaster_input_data()
 
-        outdir = os.path.dirname(args.infile)[0]
-        if not os.path.exists(outdir):
-            os.makedirs(outdir)
-        return None
-
     def _load_roaster_file(self, args):
         f = h5py.File(args.infile, 'r')
         g = f['Samples/footprint{:d}'.format(args.footprint_number)]

--- a/jiffy/sheller_great3.py
+++ b/jiffy/sheller_great3.py
@@ -78,15 +78,15 @@ def get_background_and_noise_var(data, clip_n_sigma=3, clip_converg_tol=0.1,
         # deviation values.
         sigma_frac_change = np.abs(x_std_new-x_std_old)/((x_std_new+x_std_old)/2.)
         if verbose:
-            print 'Masked {0} outlier values from this iteration.'.format(np.sum(~mask_outliers))
-            print 'Current fractional sigma change between clipping iterations = {0:0.2f}'.format(sigma_frac_change)
+            print('Masked {0} outlier values from this iteration.'.format(np.sum(~mask_outliers)))
+            print('Current fractional sigma change between clipping iterations = {0:0.2f}'.format(sigma_frac_change))
         # Replace old values with estimates from this iteration.
         x_std_old = x_std_new.copy()
         x_median_old = np.median(x)
         # Make sure that we don't have a run away while statement.
         i += 1
         if i > 100:
-            print 'Background variance failed to converge after 100 sigma clipping iterations, exiting.'
+            print('Background variance failed to converge after 100 sigma clipping iterations, exiting.')
             sys.exit()
     # Calculate the clipped image median.
     x_clip_median = np.median(x)
@@ -126,7 +126,7 @@ def create_segments(subfield_index=0, experiment="control",
         starfiles.append(os.path.join(indir,
             "starfield_image-{:03d}-{:d}.fits".format(subfield_index, epoch_index)))
     if verbose:
-        print "input files:", infiles
+        print("input files:", infiles)
 
 
     ### Load the galaxy catalog for this subfield
@@ -142,13 +142,13 @@ def create_segments(subfield_index=0, experiment="control",
         os.makedirs(segdir)
     seg_filename = os.path.join(segdir, "seg_{:03d}.h5".format(subfield_index))
     if verbose:
-        print "seg_filename:", seg_filename
+        print("seg_filename:", seg_filename)
 
     ### Set some common metadata required by the Segment file structure
     # telescope_name = "GREAT3_{}".format(observation_type)
     telescope_name = {"ground": "LSST", "space": "WFIRST"}[observation_type]
     if verbose:
-        print "telescope_name:", telescope_name
+        print("telescope_name:", telescope_name)
     filter_name = k_filter_name
     dummy_mask = 1.0
     dummy_background = 0.0
@@ -165,7 +165,7 @@ def create_segments(subfield_index=0, experiment="control",
     ngals_per_dim = 100 ### The image is a 100 x 100 grid of galaxies
     for igal in xrange(n_gals_image_file):
         if verbose and np.mod(igal, 100) == 0:
-            print "Galaxy {:d} / {:d}".format(igal+1, n_gals_image_file)
+            print("Galaxy {:d} / {:d}".format(igal+1, n_gals_image_file))
         ### Specify input image grid ranges for this segment
         ng = k_g3_ngrid[observation_type]
         i, j = np.unravel_index(igal, (ngals_per_dim, ngals_per_dim))
@@ -187,7 +187,7 @@ def create_segments(subfield_index=0, experiment="control",
             bkgrnd, noise_var = get_background_and_noise_var(f[0].data)
             noise_vars.append(noise_var)
             backgrounds.append(bkgrnd)
-            # print "empirical nosie variance: {:5.4g}".format(np.var(f[0].data))
+            # print("empirical nosie variance: {:5.4g}".format(np.var(f[0].data)))
             f.close()
 
             s = fits.open(starfiles[ifile])
@@ -199,7 +199,7 @@ def create_segments(subfield_index=0, experiment="control",
             psfs.append(np.asarray(s[0].data[0:ng, 0:ng], dtype=np.float64))
             s.close()
 
-        print "noise_vars:", noise_vars
+        print("noise_vars:", noise_vars)
         seg.save_images(images, noise_vars, [dummy_mask], backgrounds,
             segment_index=igal, telescope=telescope_name)
         seg.save_psf_images(psfs, segment_index=igal, telescope=telescope_name,


### PR DESCRIPTION
**roaster_inspector.py changes:**

- Removed a section of code that isn't doing anything:
    - Outdir gets set to `os.path.dirname(args.infile)[0]`. This creates a directory that is one character long (the first character of infile). 
    - Once it creates that directory, it never gets used in any way, so I removed the chunk of code that creates this directory.

**sheller_great3.py changes:**

- Updated print statements for python 3. (This was causing a bunch of errors to be printed when running `python setup.py install` and I wanted to clean those up).

**roaster.py changed:**

- Added a boolean argument `--unparallelize` into the argument parser section in `main()`. This should only be passed if you do NOT want to parallelize the function `do_sampling`. If `--unparallelize` is not passed, the default is to parallelize.
- `do_sampling` now has an if statement that sets `sampler` and runs `run_sampler` accordingly depending on if you want parallelization or not.
- Created a function `run_sampler` that contains the portion of the sampling code to be repeated whether you want parallelization or not. (This needed to be in a function and couldn't simply be after the if loop because it required one extra indentation level if you wanted to run with parallelization).
- Fixed line 277 print statement for python 3.
- Commented out a print statement that prints the threshold multiplier. I didn't find this print statement to be particularly useful, and it prints often. Perhaps we can add an `if verbose` statement around this.